### PR TITLE
Django 1.4 Compatibility fixes

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -19,7 +19,7 @@ class SessionStore(SessionBase):
 
     def load(self):
         try:
-            session_data = self.server.get(self.get_real_stored_key(self.session_key))
+            session_data = self.server.get(self.get_real_stored_key(self._get_or_create_session_key()))
             return self.decode(force_unicode(session_data))
         except:
             self.create()
@@ -40,17 +40,17 @@ class SessionStore(SessionBase):
             return
 
     def save(self, must_create=False):
-        if must_create and self.exists(self.session_key):
+        if must_create and self.exists(self._get_or_create_session_key()):
             raise CreateError
         data = self.encode(self._get_session(no_load=must_create))
-        self.server.set(self.get_real_stored_key(self.session_key), data)
-        self.server.expire(self.get_real_stored_key(self.session_key), self.get_expiry_age())
+        self.server.set(self.get_real_stored_key(self._get_or_create_session_key()), data)
+        self.server.expire(self.get_real_stored_key(self._get_or_create_session_key()), self.get_expiry_age())
 
     def delete(self, session_key=None):
         if session_key is None:
-            if self._session_key is None:
+            if self.session_key is None:
                 return
-            session_key = self._session_key
+            session_key = self.session_key
         try:
             self.server.delete(self.get_real_stored_key(session_key))
         except:


### PR DESCRIPTION
As far as I can tell these are the last things that need fixed to fully work with Django 1.4.

**Symptoms:**
I was running my test suite and tests were failing. Normal web browsing to the site was working, but 'bot' traffic to my site was also failing. Through debugging I found that when using a web browser, session_key was a valid hash, but when using something like curl session_key was None. 

**Background:**
In Django 1.4 SessionBase was changed to refuse non-existant user supplied session ids. SessionBase.session_key was made read only. This fix was addressed in issue #9 and pull request #10. 

It also made initialization of the session key explicit. We now need to use _get_or_create_session_key() because session_key will not always be populated. 

References:
https://github.com/django/django/blob/1.4/django/contrib/sessions/backends/cache.py
https://github.com/django/django/commit/bda21e2b9d
https://code.djangoproject.com/ticket/13478
