### PR TITLE
Add redis sentinel support

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -1,4 +1,5 @@
 import redis
+
 try:
     from django.utils.encoding import force_unicode
 except ImportError:  # Python 3.*
@@ -9,8 +10,14 @@ from redis_sessions import settings
 
 # Avoid new redis connection on each request
 
+if settings.SESSION_REDIS_SENTINEL_LIST is not None:
+    from redis.sentinel import Sentinel
 
-if settings.SESSION_REDIS_URL is not None:
+    redis_server = Sentinel(settings.SESSION_REDIS_SENTINEL_LIST, socket_timeout=0.1) \
+                    .master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS, socket_timeout=0.1)
+
+elif settings.SESSION_REDIS_URL is not None:
+
     redis_server = redis.StrictRedis.from_url(settings.SESSION_REDIS_URL)
 elif settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH is None:
     

--- a/redis_sessions/settings.py
+++ b/redis_sessions/settings.py
@@ -10,3 +10,11 @@ SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH = getattr(
     settings, 'SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH', None
 )
 SESSION_REDIS_URL = getattr(settings, 'SESSION_REDIS_URL', None)
+
+# should be on the format [(host, port), (host, port), (host, port)]
+SESSION_REDIS_SENTINEL_LIST = getattr(
+	settings, 'SESSION_REDIS_SENTINEL_LIST', None
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = getattr(
+	settings, 'SESSION_REDIS_SENTINEL_MASTER_ALIAS', None
+)


### PR DESCRIPTION
This allows to specify a list of redis sentinels to autodiscover a redis master instead of specifying a static redis master server.
