### PR TITLE
Fixed redis SETEX data type

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -20,7 +20,7 @@ elif settings.SESSION_REDIS_URL is not None:
 
     redis_server = redis.StrictRedis.from_url(settings.SESSION_REDIS_URL)
 elif settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH is None:
-    
+
     redis_server = redis.StrictRedis(
         host=settings.SESSION_REDIS_HOST,
         port=settings.SESSION_REDIS_PORT,
@@ -107,3 +107,10 @@ class SessionStore(SessionBase):
         if not prefix:
             return session_key
         return ':'.join([prefix, session_key])
+
+    def get_expiry_age(self, **kwargs):
+        """ According to http://redis.io/commands/SETEX Redis uses integer
+            value for number of seconds
+        """
+        age = super(SessionStore, self).get_expiry_age(**kwargs)
+        return int(age)


### PR DESCRIPTION
According trace from NewRelic, django tries to give session expirity value as float value. But Redis accepts only integer values for SETEX command:

```
invalid expire time in SETEX
'expires_time'  1427526823.33
```
