### PR TITLE
Added SESSION_REDIS_SOCKET_TIMEOUT config parameter

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -15,19 +15,23 @@ if settings.SESSION_REDIS_SENTINEL_LIST is not None:
 
     redis_server = Sentinel(
         settings.SESSION_REDIS_SENTINEL_LIST,
-        socket_timeout=0.1,
+        socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
         db=getattr(settings, 'SESSION_REDIS_DB', 0),
         password=getattr(settings, 'SESSION_REDIS_PASSWORD', None)
     ).master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS)
 
 elif settings.SESSION_REDIS_URL is not None:
 
-    redis_server = redis.StrictRedis.from_url(settings.SESSION_REDIS_URL)
+    redis_server = redis.StrictRedis.from_url(
+        settings.SESSION_REDIS_URL,
+        socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT
+    )
 elif settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH is None:
     
     redis_server = redis.StrictRedis(
         host=settings.SESSION_REDIS_HOST,
         port=settings.SESSION_REDIS_PORT,
+        socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
         db=settings.SESSION_REDIS_DB,
         password=settings.SESSION_REDIS_PASSWORD
     )
@@ -35,6 +39,7 @@ else:
 
     redis_server = redis.StrictRedis(
         unix_socket_path=settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH,
+        socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
         db=settings.SESSION_REDIS_DB,
         password=settings.SESSION_REDIS_PASSWORD,
     )

--- a/redis_sessions/settings.py
+++ b/redis_sessions/settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 SESSION_REDIS_HOST = getattr(settings, 'SESSION_REDIS_HOST', 'localhost')
 SESSION_REDIS_PORT = getattr(settings, 'SESSION_REDIS_PORT', 6379)
+SESSION_REDIS_SOCKET_TIMEOUT = getattr(settings, 'SESSION_REDIS_SOCKET_TIMEOUT', 0.1)
 SESSION_REDIS_DB = getattr(settings, 'SESSION_REDIS_DB', 0)
 SESSION_REDIS_PREFIX = getattr(settings, 'SESSION_REDIS_PREFIX', '')
 SESSION_REDIS_PASSWORD = getattr(settings, 'SESSION_REDIS_PASSWORD', None)


### PR DESCRIPTION
In several situations, the default socket timeout is not suitable.
This PR introduces a configuration parameter to control it.