### PR TITLE
Set retry_on_timeout from settings

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -16,6 +16,7 @@ if settings.SESSION_REDIS_SENTINEL_LIST is not None:
     redis_server = Sentinel(
         settings.SESSION_REDIS_SENTINEL_LIST,
         socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
+        retry_on_timeout=settings.SESSION_REDIS_RETRY_ON_TIMEOUT,
         db=getattr(settings, 'SESSION_REDIS_DB', 0),
         password=getattr(settings, 'SESSION_REDIS_PASSWORD', None)
     ).master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS)
@@ -32,6 +33,7 @@ elif settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH is None:
         host=settings.SESSION_REDIS_HOST,
         port=settings.SESSION_REDIS_PORT,
         socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
+        retry_on_timeout=settings.SESSION_REDIS_RETRY_ON_TIMEOUT,
         db=settings.SESSION_REDIS_DB,
         password=settings.SESSION_REDIS_PASSWORD
     )
@@ -40,6 +42,7 @@ else:
     redis_server = redis.StrictRedis(
         unix_socket_path=settings.SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH,
         socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
+        retry_on_timeout=settings.SESSION_REDIS_RETRY_ON_TIMEOUT,
         db=settings.SESSION_REDIS_DB,
         password=settings.SESSION_REDIS_PASSWORD,
     )

--- a/redis_sessions/settings.py
+++ b/redis_sessions/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 SESSION_REDIS_HOST = getattr(settings, 'SESSION_REDIS_HOST', 'localhost')
 SESSION_REDIS_PORT = getattr(settings, 'SESSION_REDIS_PORT', 6379)
 SESSION_REDIS_SOCKET_TIMEOUT = getattr(settings, 'SESSION_REDIS_SOCKET_TIMEOUT', 0.1)
+SESSION_REDIS_RETRY_ON_TIMEOUT = getattr(settings, 'SESSION_REDIS_RETRY_ON_TIMEOUT', False)
 SESSION_REDIS_DB = getattr(settings, 'SESSION_REDIS_DB', 0)
 SESSION_REDIS_PREFIX = getattr(settings, 'SESSION_REDIS_PREFIX', '')
 SESSION_REDIS_PASSWORD = getattr(settings, 'SESSION_REDIS_PASSWORD', None)


### PR DESCRIPTION
In case of time-out, Redis client can automatically retry once if a `retry_on_timeout` parameter is set to `True` (it's `False` by default). It's useful sometimes and this PR introduces an option to configure it in settings.