### PR TITLE
Extend session TTL on load()

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -108,9 +108,14 @@ class SessionStore(SessionBase):
 
     def load(self):
         try:
-            session_data = self.server.get(
-                self.get_real_stored_key(self._get_or_create_session_key())
-            )
+            exists = self._session_key is not None
+            stored_key = self.get_real_stored_key(self._get_or_create_session_key())
+            session_data = self.server.get(stored_key)
+            if exists:
+                self.server.expire(
+                    stored_key,
+                    self.get_expiry_age(expiry=None)  # expiry=None prevents get_expiry_age() to call load()
+                )
             return self.decode(force_unicode(session_data))
         except:
             self._session_key = None


### PR DESCRIPTION
It seems to me (after looking into the TTL value of the session in Redis while browsing the Django webapp) that the session expiry is never extended on access. This means that the user is logged out from their session after the value specified in the settings (`settings.SESSION_COOKIE_AGE`) regardless of how active they have been during that time. They will loose any changes on the page, e.g. in a form, if they have been working on something when that TTL ends.

This pull requests simply extends the TTL on each call of `redis_sessions.SessionStore.load()` if the `_session_key` is not `None` (the session exists already).

Maybe there is a better way to achieve this?

There is an older issue #40 about this but with no solution.