### PR TITLE
Sentinel requires DB and PASSWORD from settings

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -67,8 +67,8 @@ class RedisServer():
                 settings.SESSION_REDIS_SENTINEL_LIST,
                 socket_timeout=settings.SESSION_REDIS_SOCKET_TIMEOUT,
                 retry_on_timeout=settings.SESSION_REDIS_RETRY_ON_TIMEOUT,
-                db=getattr(settings, 'db', 0),
-                password=getattr(settings, 'password', None)
+                db=getattr(settings, 'SESSION_REDIS_DB', 0),
+                password=getattr(settings, 'SESSION_REDIS_PASSWORD', None)
             ).master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS)
 
         elif self.connection_type == 'redis_url':


### PR DESCRIPTION
A change got introduced in 839380f9820d7ca37e11cc78881487ba345bbed8, but it looks like @martinrusev was a bit eager and changed the `getattr` for Sentinel too. I believe these should still look for the regular settings.