### PR TITLE
ERROR when use request.session.clear_expired()

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -162,6 +162,10 @@ class SessionStore(SessionBase):
         except:
             pass
 
+    @classmethod
+    def clear_expired(cls):
+        pass
+        
     def get_real_stored_key(self, session_key):
         """Return the real key name in redis storage
         @return string


### PR DESCRIPTION
Need to add clear_expired method like django/contrib/sessions/backends/cache.py:
```python
    @classmethod
    def clear_expired(cls):
        pass
```
or it will raise NotImplementedError in django/contrib/sessions/backends/base.py
```python
    @classmethod
    def clear_expired(cls):
        """
        Remove expired sessions from the session store.

        If this operation isn't possible on a given backend, it should raise
        NotImplementedError. If it isn't necessary, because the backend has
        a built-in expiration mechanism, it should be a no-op.
        """
        raise NotImplementedError
```
This error occured when we changed to use your SESSION_ENGINE and our code already use the method `clear_expired`

