### PR TITLE
Fix "RemovedInDjango40Warning: force_text()..." warning

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -3,7 +3,7 @@ import redis
 try:
     from django.utils.encoding import force_unicode
 except ImportError:  # Python 3.*
-    from django.utils.encoding import force_text as force_unicode
+    from django.utils.encoding import force_str as force_unicode
 from django.contrib.sessions.backends.base import SessionBase, CreateError
 from redis_sessions import settings
 


### PR DESCRIPTION
Currently, as of Django 3.0 (https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0), importing `force_text` causes a warning notice. This can clutter up test runs as warnings are surfaced by `pytest`, and other tools may have this issue as well.

The method has been renamed to `force_str`. However, note that `force_str` is not to be used with python 2.7, where you should instead continue to use `force_unicode`.

This PR fixes this issue while supporting all known configurations of python and django versions.

**Please verify this fix, as I am not set up properly with your testing environment.**