### PR TITLE
handle non-existing session key in Redis

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -125,13 +125,17 @@ class SessionStore(SessionBase):
 
     def load(self):
         try:
-            session_data = self.server.get(
-                self.get_real_stored_key(self._get_or_create_session_key())
-            )
+            session_key = self._get_or_create_session_key()
+            real_stored_session_key = self.get_real_stored_key(session_key)
+            session_data = self.server.get(real_stored_session_key)
+        except Exception:
+            session_data = None
+
+        if session_data is not None:
             return self.decode(force_unicode(session_data))
-        except:
-            self._session_key = None
-            return {}
+
+        self._session_key = None
+        return {}
 
     def exists(self, session_key):
         return self.server.exists(self.get_real_stored_key(session_key))


### PR DESCRIPTION
## Purpose

When the key does not exist in Redis, the `get()` returns `None` and this `None` gets passed as a string to `decode()`. In Django 3 `decode()` silently detected the error and returned an empty session, Django 4 additionally emits a log that the session data is corrupt.

## Approach

Handle case where `get` in Redis session backend returns `None`.
This code is now in-line with what `django.contrib.sessions.backend.cache` does.

## Where should the reviewer start?

* Handling in Django's own Redis session backend: https://github.com/django/django/blob/3.2.19/django/contrib/sessions/backends/cache.py#L24
* Django 3.2 silent error handling when `decode()` fails: https://github.com/django/django/blob/3.2.19/django/contrib/sessions/backends/base.py#L159
* Django 4.2 log when `decode()` fails (fallback to `_legacy_decode()` is removed): https://github.com/django/django/blob/4.2.2/django/contrib/sessions/backends/base.py#L108 

## Quality assurance

I have a test case but since the test suite is not running on latest Python due to `nose` being unmaintained it I didn't add it in this PR.

```
@mock.patch("redis_sessions.session.SessionStore.decode")
def test_session_load_session_data_none(decode_mock):
    session = SessionStore("someunknownkey")
    session._session_key = "keywhichdoesntexist"
    result = session.load()
    assert session._session_key is None
    assert result == {}
    decode_mock.assert_not_called()
```

I have also been running this patched version in a production environment for a few weeks.